### PR TITLE
galaxy package name change

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -20,7 +20,7 @@ roles:
     version: v1.14.0
   - src: mrlesmithjr.chrony
     version: v0.1.4
-  - src: mrlesmithjr.manage-lvm
+  - src: mrlesmithjr.manage_lvm
     version: v0.2.8
   - src: mrlesmithjr.mdadm
     version: v0.1.1


### PR DESCRIPTION
An ansible galaxy package has had its name changed:

https://github.com/mrlesmithjr/ansible-manage-lvm/issues/105