### PR TITLE
added extra sanity check for --enable-discovery without limiting

### DIFF
--- a/kayobe/cli/commands.py
+++ b/kayobe/cli/commands.py
@@ -408,8 +408,13 @@ class PhysicalNetworkConfigure(KayobeAnsibleMixin, VaultMixin, Command):
         self.app.LOG.debug("Configuring a physical network")
         extra_vars = {}
         extra_vars["physical_network_display"] = parsed_args.display
-        if parsed_args.enable_discovery:
-            extra_vars["physical_network_enable_discovery"] = True
+        if parsed_args.disable_discovery:
+            if not parsed_args.interface_limit or not parsed_args.interface_description:
+                user_input = input('Are you sure? This could break everything! [y/N]')
+                if(user_input.lower() == 'y'):
+                    extra_vars["physical_network_disable_discovery"] = True
+                else:
+                    exit()
         if parsed_args.disable_discovery:
             extra_vars["physical_network_disable_discovery"] = True
         if parsed_args.interface_limit:


### PR DESCRIPTION
After breaking an entire cluster by using --enable-discovery without limiting with --interface_limit or --interface_description I added an extra sanity check.